### PR TITLE
Add support for LDAP user profile attributes selection.

### DIFF
--- a/lib/initConf.js
+++ b/lib/initConf.js
@@ -9,6 +9,7 @@ var defaults = {
   LDAP_SEARCH_LIST_GROUPS_QUERY:        '(objectCategory=group)',
   LDAP_SEARCH_GROUPS:                   '(member:1.2.840.113556.1.4.1941:={0})',
   LDAP_USER_BY_NAME:                    '(sAMAccountName={0})',
+  LDAP_USER_BY_NAME_ATTRS:              null,
   LDAP_NUMBER_OF_PARALLEL_BINDS:        1,
   LDAP_HEARTBEAT_SEARCH_QUERY:          '(&(objectclass=user)(|(sAMAccountName=foo)(UserPrincipalName=foo)))',
   WSFED_ISSUER:                         'urn:auth0',

--- a/lib/users.js
+++ b/lib/users.js
@@ -321,7 +321,11 @@ Users.prototype.getByUserName = function (userName, options, callback) {
   const filter = parseLdapFilter(nconf.get('LDAP_USER_BY_NAME').replace(/\{0\}/g, searchUsername));
   if (!filter.isValid) return callback(null);  // Input username does not resolve to valid ldap filter, return no match
 
-  var opts = { scope: 'sub', filter: filter.filter };
+  var opts = {
+    scope: 'sub',
+    filter: filter.filter,
+    attributes: nconf.get('LDAP_USER_BY_NAME_ATTRS')
+  };
   var entries = [];
 
   var done = cb(function (err) {

--- a/test/resources/mock_ldap_data.json
+++ b/test/resources/mock_ldap_data.json
@@ -44,7 +44,8 @@
     "sn": "doe",
     "uid": "jdoe",
     "uidNumber": "1000",
-    "userPassword": "123"
+    "userPassword": "123",
+    "extraAttribute": "extra-val-666"
   },
   "cn=mdoe,ou=users,dc=example,dc=org": {
     "cn": "mdoe",

--- a/test/users.unit.tests.js
+++ b/test/users.unit.tests.js
@@ -43,6 +43,7 @@ describe("users", function () {
           expect(err).to.be.null;
           expect(user.cn).to.equal("jdoe");
           expect(user.mail).to.equal("jdoe@example.org");
+          expect(user.extraAttribute).to.equal("extra-val-666");
           done();
         });
       });
@@ -56,6 +57,35 @@ describe("users", function () {
           done();
         });
       });
+
+      it("should return requested attribute only for existing user", function (done) {
+        nconf.set("LDAP_USER_BY_NAME_ATTRS", ['mail']);
+        const users = new Users();
+
+        users.getByUserName("jdoe", {}, function (err, user) {
+          nconf.set("LDAP_USER_BY_NAME_ATTRS", null); // reset.
+          expect(err).to.be.null;
+          expect(user.cn).to.be.undefined;
+          expect(user.mail).to.equal("jdoe@example.org");
+          expect(user.extraAttribute).to.be.undefined;
+          done();
+        });
+      });
+
+      it("should return requested default and specific attributes for existing user", function (done) {
+        nconf.set("LDAP_USER_BY_NAME_ATTRS", ['*', 'extraAttribute']);
+        const users = new Users();
+
+        users.getByUserName("jdoe", {}, function (err, user) {
+          nconf.set("LDAP_USER_BY_NAME_ATTRS", null); // reset.
+          expect(err).to.be.null;
+          expect(user.cn).to.equal("jdoe");
+          expect(user.mail).to.equal("jdoe@example.org");
+          expect(user.extraAttribute).to.equal("extra-val-666");
+          done();
+        });
+      });
+
     });
 
     describe("when username is not valid", function () {


### PR DESCRIPTION
Add support for LDAP user profile attributes selection.

Via new configuration option: `LDAP_USER_BY_NAME_ATTRS`, a value to pass through to the underlying LDAPjs library as the `attributes` option for `Users.getByUserName`.

Current behaviour is maintained, select the default set of attributes, which equates to a null value for the option.

To include operational attributes in addition to the defaults, use a list containing an asterisk (meaning defaults) and the operational attributes: `[ "*", "att1", "att2" ]`

To include ALL attributes, defaults and operational: `[ "*", "+" ]`

More generally, to select only specific attribute(s) (regular or operational), specify each in the list: `[ "att1", "att2" ]`